### PR TITLE
fix: hamburgermeny (brekkpunkter, spacing, etc)

### DIFF
--- a/src/components/Breakpoints.js
+++ b/src/components/Breakpoints.js
@@ -1,3 +1,7 @@
 export const onDesktop = styles => `@media screen and (min-width: 720px) {
     ${styles}
   }`;
+
+export const onMobile = styles => `@media only screen and (max-width: 719px) {
+    ${styles}
+}`;

--- a/src/components/ClaveLink.js
+++ b/src/components/ClaveLink.js
@@ -3,6 +3,7 @@ import { Link } from 'gatsby';
 import styled from 'styled-components';
 import { COLOR_CLAVE_PINK, COLOR_CLAVE_GREEN } from '../colors';
 import { ColorContext } from './Layout';
+import { onMobile } from './Breakpoints';
 
 const ClaveLink = ({ to, children, className, ...props }) => {
   const { textColor } = useContext(ColorContext);
@@ -19,9 +20,9 @@ const ClaveLink = ({ to, children, className, ...props }) => {
 };
 
 const ANCHOR_STYLES = `
-  @media only screen and (max-width: 600px) {
+  ${onMobile(`
     display: none;
-  }
+  `)}
   text-decoration: none;
   padding-bottom: 5px;
   border-bottom: 1px solid ${COLOR_CLAVE_PINK};

--- a/src/components/HamburgerMenuLink.js
+++ b/src/components/HamburgerMenuLink.js
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+import { Link } from 'gatsby';
+import styled from 'styled-components';
+import { COLOR_CLAVE_PINK, COLOR_CLAVE_GREEN } from '../colors';
+import { ColorContext } from './Layout';
+
+const HamburgerMenuLink = ({ to, children, className, ...props }) => {
+  const { textColor } = useContext(ColorContext);
+
+  const ColoredLink = styled(Link)`
+    color: ${textColor || COLOR_CLAVE_GREEN};
+    text-decoration: none;
+    border-bottom: 1px solid ${COLOR_CLAVE_PINK};
+    display: table;
+    padding: 0.5rem 0;
+  `;
+
+  return (
+    <ColoredLink className={className} to={to} {...props}>
+      {children}
+    </ColoredLink>
+  );
+};
+
+export default HamburgerMenuLink;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useContext, useState } from 'react';
 import { COLOR_CLAVE_GREEN, COLOR_CLAVE_SKIN } from '../colors';
 import styled from 'styled-components';
@@ -8,43 +7,34 @@ import { Link } from 'gatsby';
 import hamburgerIcon from './icons/hamburgermeny_ikon.svg';
 import { ColorContext, Container, DESKTOP_PADDING, MOBILE_PADDING } from './Layout';
 import { onDesktop } from './Breakpoints';
+import HamburgerMenuLink from './HamburgerMenuLink';
 
 const Header = ({ frontPage = false, useSkinColoredHamburgerMenu = false }) => {
-  const HamburgerDiv = styled.div``;
-  const [menuExpanded, setMenuExpanded] = useState(false);
-  const LogoComponent = frontPage ? FrontPageLogo : Logo;
-  const LinkComponent = styled(ClaveLink)`
-    display: none;
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
-
-    ${onDesktop(`
-      display: block;
-    `)}
-  `;
-
-  const HanburgerMenuLink = styled(ClaveLink)`
-    display: table;
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
-    padding-bottom: 0px;!important
+  const HamburgerDiv = styled.div`
+    padding-bottom: 2rem;
     ${onDesktop(`
       display: none;
     `)}
+  `;
+  const [menuExpanded, setMenuExpanded] = useState(false);
+  const LogoComponent = frontPage ? FrontPageLogo : Logo;
+  const LinkComponent = styled(ClaveLink)`
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
   `;
 
   const HamburgerMenyOptions = () => {
     return menuExpanded ? (
       <HamburgerDiv>
-        <HanburgerMenuLink to="/hva-vi-gjor">
+        <HamburgerMenuLink to="/hva-vi-gjor">
           Se hva vi gjør
-        </HanburgerMenuLink>
-        <HanburgerMenuLink to="/hvem-vi-er">
+        </HamburgerMenuLink>
+        <HamburgerMenuLink to="/hvem-vi-er">
           Se hvem vi er
-        </HanburgerMenuLink>
-        <HanburgerMenuLink to="/kontakt-oss">
+        </HamburgerMenuLink>
+        <HamburgerMenuLink to="/kontakt-oss">
           Kontakt oss
-        </HanburgerMenuLink>
+        </HamburgerMenuLink>
       </HamburgerDiv>
     ) : (
       ''
@@ -177,10 +167,6 @@ const FrontPageWrapper = styled(Wrapper)`
   background: none;
   padding: ${PADDING_VERTICAL} 0;
 `;
-
-Header.propTypes = {
-  children: PropTypes.string,
-};
 
 const StyledHamburgerIcon = styled(hamburgerIcon)`
   width: 2rem;


### PR DESCRIPTION
Fikset:
- ekspandert hamburgermeny hang igjen dersom man gikk til landskapsmodus
- hamburgermenyen kom samtidig som CTA lenker pga forskjellige brekkpunkter (600 for CTA, 720 for hamburgermeny)
- lagt på litt mer luft