### PR TITLE
Fix på avkutting av bilde

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -57,7 +57,7 @@ const Header = ({ frontPage = false, useSkinColoredHamburgerMenu = false }) => {
 
   const newColorContext = frontPage
     ? {
-      backgroundColor: COLOR_CLAVE_GREEN,
+      backgroundColor: "none",
       textColor: COLOR_CLAVE_SKIN,
     }
     : colorContext;


### PR DESCRIPTION
Avkutting av bilde er borte, men bilde vil havne bak "Kontakt oss" i headeren om skjermen som brukes er for bred ift høyde.

Ta en titt