### PR TITLE
Felles layout, native view transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,51 @@
-# Astro Starter Kit: Basics
+# Clave hjemmeside
 
-```sh
-npm create astro@latest -- --template basics
-```
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
+## 🚀 Prosjektstruktur
 
 ```text
 /
 ├── public/
-│   └── favicon.svg
+│   ├── clave-icon.png
+│   └── fonts/
+│       └── basis/               # Basis Grotesque Pro (woff2, woff, ttf, eot)
 ├── src/
+│   ├── assets/
+│   │   ├── icons/               # SVG-ikoner (tjenester, logo, hamburger)
+│   │   ├── apenhetsloven/       # PDF-vedlegg
+│   │   └── ...                  # Fotografi-assets
 │   ├── components/
-│   │   └── Card.astro
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
+│   │   ├── layout/
+│   │   │   ├── BaseLayout.astro # Felles html/head/body-shell for alle sider
+│   │   │   └── ...
+│   │   ├── icons/
+│   │   │   └── ...
+│   │   ├── dette-er-oss/
+│   │   │   ├── ansatte.json
+│   │   │   ├── bilder/          # Ansattbilder (jpg/svg)
+│   │   │   └── ...
+│   │   └── ...
+│   ├── pages/
+│   │   ├── index.astro
+│   │   ├── prosjekter/
+│   │   │   ├── naf.astro
+│   │   │   └── ...
+│   │   └── ...
+│   ├── styles/
+│   │   └── global.css
+│   ├── colors.js                # Fargekonstanter (COLOR_CLAVE_*)
+│   ├── layouts.js               # Layout-konstanter (MAX_WIDTH, MOBILE_PADDING)
+│   └── types.ts
 └── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## 🧞 Kommandoer
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+Alle kommandoer kjøres fra rotnivå:
 
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
+| Kommando                  | Handling                                         |
 | :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+| `npm install`             | Installer avhengigheter                          |
+| `npm run dev`             | Start lokal dev-server på `localhost:4321`       |
+| `npm run build`           | Bygg produksjonsside til `./dist/`               |
+| `npm run preview`         | Forhåndsvis bygget lokalt før deploy             |
+| `npm run astro ...`       | Kjør Astro CLI-kommandoer                        |

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -43,19 +43,32 @@ import frontpageImage from "../assets/frontpage1.png";
 </section>
 
 <script>
-  const overlay = document.getElementById("scroll-overlay");
-  const isLandscape = () => window.innerWidth >= window.innerHeight;
+  let currentHandler: (() => void) | null = null;
 
-  const setClipPath = () => {
+  function initScrollAnimation() {
+    if (currentHandler) {
+      window.removeEventListener("scroll", currentHandler);
+      currentHandler = null;
+    }
+
+    const overlay = document.getElementById("scroll-overlay");
     if (!overlay) return;
-    const scrollY = window.scrollY;
-    overlay.style.clipPath = isLandscape()
-      ? `circle(calc(${1.5 * scrollY}px + min(45vh, 45vw)) at 85% 70%)`
-      : `circle(calc(${scrollY}px + 25vh) at 85% 85%)`;
-  };
 
-  setClipPath();
-  window.addEventListener("scroll", setClipPath);
+    const isLandscape = () => window.innerWidth >= window.innerHeight;
+
+    const setClipPath = () => {
+      const scrollY = window.scrollY;
+      overlay.style.clipPath = isLandscape()
+        ? `circle(calc(${1.5 * scrollY}px + min(45vh, 45vw)) at 85% 70%)`
+        : `circle(calc(${scrollY}px + 25vh) at 85% 85%)`;
+    };
+
+    setClipPath();
+    window.addEventListener("scroll", setClipPath);
+    currentHandler = setClipPath;
+  }
+
+  document.addEventListener("astro:page-load", initScrollAnimation);
 </script>
 
 <style>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -43,32 +43,19 @@ import frontpageImage from "../assets/frontpage1.png";
 </section>
 
 <script>
-  let currentHandler: (() => void) | null = null;
+  const overlay = document.getElementById("scroll-overlay");
+  const isLandscape = () => window.innerWidth >= window.innerHeight;
 
-  function initScrollAnimation() {
-    if (currentHandler) {
-      window.removeEventListener("scroll", currentHandler);
-      currentHandler = null;
-    }
-
-    const overlay = document.getElementById("scroll-overlay");
+  const setClipPath = () => {
     if (!overlay) return;
+    const scrollY = window.scrollY;
+    overlay.style.clipPath = isLandscape()
+      ? `circle(calc(${1.5 * scrollY}px + min(45vh, 45vw)) at 85% 70%)`
+      : `circle(calc(${scrollY}px + 25vh) at 85% 85%)`;
+  };
 
-    const isLandscape = () => window.innerWidth >= window.innerHeight;
-
-    const setClipPath = () => {
-      const scrollY = window.scrollY;
-      overlay.style.clipPath = isLandscape()
-        ? `circle(calc(${1.5 * scrollY}px + min(45vh, 45vw)) at 85% 70%)`
-        : `circle(calc(${scrollY}px + 25vh) at 85% 85%)`;
-    };
-
-    setClipPath();
-    window.addEventListener("scroll", setClipPath);
-    currentHandler = setClipPath;
-  }
-
-  document.addEventListener("astro:page-load", initScrollAnimation);
+  setClipPath();
+  window.addEventListener("scroll", setClipPath);
 </script>
 
 <style>

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -1,5 +1,4 @@
 ---
-import { ClientRouter } from 'astro:transitions';
 import '../../styles/global.css';
 
 interface Props {
@@ -16,7 +15,6 @@ const { title, backgroundColor, bodyStyle } = Astro.props;
   <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{title}</title>
-  <ClientRouter />
 </head>
 <body style={`background-color: ${backgroundColor};${bodyStyle ? ' ' + bodyStyle : ''}`}>
   <slot />

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -1,0 +1,24 @@
+---
+import { ClientRouter } from 'astro:transitions';
+import '../../styles/global.css';
+
+interface Props {
+  title: string;
+  backgroundColor: string;
+  bodyStyle?: string;
+}
+
+const { title, backgroundColor, bodyStyle } = Astro.props;
+---
+<html lang="nb">
+<head>
+  <meta charset="utf-8">
+  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title}</title>
+  <ClientRouter />
+</head>
+<body style={`background-color: ${backgroundColor};${bodyStyle ? ' ' + bodyStyle : ''}`}>
+  <slot />
+</body>
+</html>

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -3,11 +3,9 @@ import '../../styles/global.css';
 
 interface Props {
   title: string;
-  backgroundColor: string;
-  bodyStyle?: string;
 }
 
-const { title, backgroundColor, bodyStyle } = Astro.props;
+const { title } = Astro.props;
 ---
 <html lang="nb">
 <head>
@@ -16,7 +14,7 @@ const { title, backgroundColor, bodyStyle } = Astro.props;
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{title}</title>
 </head>
-<body style={`background-color: ${backgroundColor};${bodyStyle ? ' ' + bodyStyle : ''}`}>
+<body>
   <slot />
 </body>
 </html>

--- a/src/components/layout/Container.astro
+++ b/src/components/layout/Container.astro
@@ -14,9 +14,13 @@ const {
 } = Astro.props;
 ---
 
-<div
-  class:list={["container", className]}
-  style={`background-color: ${backgroundColor}; color: ${textColor}; --clave-bg: ${backgroundColor}; --clave-text: ${textColor};`}
->
+<div class:list={["container", className]}>
   <slot />
 </div>
+
+<style define:vars={{ 'clave-bg': backgroundColor, 'clave-text': textColor }}>
+  .container {
+    background-color: var(--clave-bg);
+    color: var(--clave-text);
+  }
+</style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,8 +7,8 @@ import Footer from '../components/layout/Footer.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
 ---
 
-<BaseLayout title="404 | clave" backgroundColor={COLOR_CLAVE_PEACH} bodyStyle="height: 100%; display: flex; flex-direction: column;">
-  <Container backgroundColor={COLOR_CLAVE_PEACH} textColor={COLOR_CLAVE_GREEN}>
+<BaseLayout title="404 | clave">
+  <Container>
     <main>
       <Header />
       <Layout backgroundColor={COLOR_CLAVE_PEACH} textColor={COLOR_CLAVE_GREEN}>
@@ -24,8 +24,14 @@ import BaseLayout from '../components/layout/BaseLayout.astro';
 </BaseLayout>
 
 <style>
-  :global(html) {
+  :global(html),
+  :global(body) {
     height: 100%;
+  }
+
+  :global(body) {
+    display: flex;
+    flex-direction: column;
   }
 
   :global(body) > :global(.container) {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,17 +4,10 @@ import Container from '../components/layout/Container.astro';
 import Header from '../components/layout/Header.astro';
 import Layout from '../components/layout/Layout.astro';
 import Footer from '../components/layout/Footer.astro';
-import '../styles/global.css';
+import BaseLayout from '../components/layout/BaseLayout.astro';
 ---
 
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>404 | clave</title>
-</head>
-<body>
+<BaseLayout title="404 | clave" backgroundColor={COLOR_CLAVE_PEACH} bodyStyle="height: 100%; display: flex; flex-direction: column;">
   <Container backgroundColor={COLOR_CLAVE_PEACH} textColor={COLOR_CLAVE_GREEN}>
     <main>
       <Header />
@@ -28,19 +21,14 @@ import '../styles/global.css';
     </main>
     <Footer backgroundColor={COLOR_CLAVE_PEACH} textColor={COLOR_CLAVE_GREEN} />
   </Container>
-</body>
+</BaseLayout>
 
 <style>
-  html, body {
+  :global(html) {
     height: 100%;
   }
 
-  body {
-    display: flex;
-    flex-direction: column;
-  }
-
-  body > :global(.container) {
+  :global(body) > :global(.container) {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -50,4 +38,3 @@ import '../styles/global.css';
     flex: 1;
   }
 </style>
-</html>

--- a/src/pages/apenhetsloven.astro
+++ b/src/pages/apenhetsloven.astro
@@ -2,18 +2,11 @@
 import pdf from "../assets/apenhetsloven/Åpenhetsloven Clave Consulting AS.pdf";
 import Header from "../components/layout/Header.astro";
 import Container from "../components/layout/Container.astro";
+import BaseLayout from "../components/layout/BaseLayout.astro";
 import { COLOR_CLAVE_PEACH, COLOR_CLAVE_GREEN } from "../colors.js";
-import "../styles/global.css";
 ---
 
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Åpenhetsloven | clave</title>
-</head>
-<body>
+<BaseLayout title="Åpenhetsloven | clave" backgroundColor={COLOR_CLAVE_PEACH}>
   <Container backgroundColor={COLOR_CLAVE_PEACH} textColor={COLOR_CLAVE_GREEN}>
     <Header uri="/apenhetsloven" />
     <div class="title">
@@ -24,8 +17,7 @@ import "../styles/global.css";
       </ul>
     </div>
   </Container>
-</body>
-</html>
+</BaseLayout>
 
 <style>
   .title {

--- a/src/pages/apenhetsloven.astro
+++ b/src/pages/apenhetsloven.astro
@@ -3,11 +3,10 @@ import pdf from "../assets/apenhetsloven/Åpenhetsloven Clave Consulting AS.pdf"
 import Header from "../components/layout/Header.astro";
 import Container from "../components/layout/Container.astro";
 import BaseLayout from "../components/layout/BaseLayout.astro";
-import { COLOR_CLAVE_PEACH, COLOR_CLAVE_GREEN } from "../colors.js";
 ---
 
-<BaseLayout title="Åpenhetsloven | clave" backgroundColor={COLOR_CLAVE_PEACH}>
-  <Container backgroundColor={COLOR_CLAVE_PEACH} textColor={COLOR_CLAVE_GREEN}>
+<BaseLayout title="Åpenhetsloven | clave">
+  <Container>
     <Header uri="/apenhetsloven" />
     <div class="title">
       <h1>Redegjørelse etter åpenhetsloven</h1>

--- a/src/pages/hva-vi-gjor.astro
+++ b/src/pages/hva-vi-gjor.astro
@@ -11,9 +11,8 @@ import pointingBilde from '../assets/190920_Clave_lowres_9.jpg';
 import larsPetterBilde from '../assets/190920_Clave_lowres_14.jpg';
 import laptopBilde from '../assets/190920_Clave_lowres_16.jpg';
 import BaseLayout from '../components/layout/BaseLayout.astro';
-import { COLOR_CLAVE_PEACH } from '../colors.js';
 ---
-<BaseLayout title="Se hva vi gjør | clave" backgroundColor={COLOR_CLAVE_PEACH}>
+<BaseLayout title="Se hva vi gjør | clave">
   <Container>
     <main>
       <Header uri="/hva-vi-gjor" />

--- a/src/pages/hva-vi-gjor.astro
+++ b/src/pages/hva-vi-gjor.astro
@@ -10,15 +10,10 @@ import headerBilde from '../assets/190920_Clave_lowres_2.jpg';
 import pointingBilde from '../assets/190920_Clave_lowres_9.jpg';
 import larsPetterBilde from '../assets/190920_Clave_lowres_14.jpg';
 import laptopBilde from '../assets/190920_Clave_lowres_16.jpg';
+import BaseLayout from '../components/layout/BaseLayout.astro';
+import { COLOR_CLAVE_PEACH } from '../colors.js';
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Se hva vi gjør | clave</title>
-</head>
-<body>
+<BaseLayout title="Se hva vi gjør | clave" backgroundColor={COLOR_CLAVE_PEACH}>
   <Container>
     <main>
       <Header uri="/hva-vi-gjor" />
@@ -89,8 +84,7 @@ import laptopBilde from '../assets/190920_Clave_lowres_16.jpg';
     </main>
     <Footer />
   </Container>
-</body>
-</html>
+</BaseLayout>
 
 <style>
   .user-testing-block {

--- a/src/pages/hvem-vi-er.astro
+++ b/src/pages/hvem-vi-er.astro
@@ -7,9 +7,8 @@ import PageHeader from '../components/PageHeader.astro';
 import EmployeeList from '../components/dette-er-oss/EmployeeList.astro';
 import headerBilde from '../assets/190920_Clave_lowres_11.jpg';
 import BaseLayout from '../components/layout/BaseLayout.astro';
-import { COLOR_CLAVE_PEACH } from '../colors.js';
 ---
-<BaseLayout title="Se hvem vi er | clave" backgroundColor={COLOR_CLAVE_PEACH}>
+<BaseLayout title="Se hvem vi er | clave">
   <Container>
     <main>
       <Header uri="/hvem-vi-er" />

--- a/src/pages/hvem-vi-er.astro
+++ b/src/pages/hvem-vi-er.astro
@@ -6,15 +6,10 @@ import Footer from '../components/layout/Footer.astro';
 import PageHeader from '../components/PageHeader.astro';
 import EmployeeList from '../components/dette-er-oss/EmployeeList.astro';
 import headerBilde from '../assets/190920_Clave_lowres_11.jpg';
+import BaseLayout from '../components/layout/BaseLayout.astro';
+import { COLOR_CLAVE_PEACH } from '../colors.js';
 ---
-<html lang="nb">
-<head>
-    <meta charset="utf-8">
-    <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Se hvem vi er | clave</title>
-</head>
-<body>
+<BaseLayout title="Se hvem vi er | clave" backgroundColor={COLOR_CLAVE_PEACH}>
   <Container>
     <main>
       <Header uri="/hvem-vi-er" />
@@ -55,6 +50,5 @@ import headerBilde from '../assets/190920_Clave_lowres_11.jpg';
     </main>
     <Footer />
   </Container>
-</body>
-</html>
+</BaseLayout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import systemutviklingIcon from '../assets/icons/clave_ikon_systemutvikling.svg?
 import raadgivningIcon from '../assets/icons/clave_ikon_radgivning.svg?url';
 ---
 
-<BaseLayout title="Forside | clave" backgroundColor={COLOR_CLAVE_PEACH}>
+<BaseLayout title="Forside | clave">
   <main>
     <HeroSection />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,22 +5,14 @@ import Layout from '../components/layout/Layout.astro';
 import Container from '../components/layout/Container.astro';
 import JoinSection from '../components/layout/JoinSection.astro';
 import Footer from '../components/layout/Footer.astro';
+import BaseLayout from '../components/layout/BaseLayout.astro';
 
 import brukeropplevelseIcon from '../assets/icons/clave_ikon_brukeropplevelse.svg?url';
 import systemutviklingIcon from '../assets/icons/clave_ikon_systemutvikling.svg?url';
 import raadgivningIcon from '../assets/icons/clave_ikon_radgivning.svg?url';
-
-import '../styles/global.css';
 ---
 
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Forside | clave</title>
-</head>
-<body>
+<BaseLayout title="Forside | clave" backgroundColor={COLOR_CLAVE_PEACH}>
   <main>
     <HeroSection />
 
@@ -80,8 +72,7 @@ import '../styles/global.css';
 
   <!-- Simple Analytics - 100% privacy-first analytics -->
   <script is:inline async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
-</body>
-</html>
+</BaseLayout>
 
 <style>
   .ingress-wrapper {

--- a/src/pages/jobb-som-designer.astro
+++ b/src/pages/jobb-som-designer.astro
@@ -4,13 +4,12 @@ import Ingress from '../components/Ingress.astro';
 import MidSplitLayout from '../components/MidSplitLayout.astro';
 import RecruitmentTemplate from '../components/RecruitmentTemplate.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
-import { COLOR_CLAVE_PEACH } from '../colors.js';
 import type { Position } from '../types';
 import piaBilde from '../assets/190920_Clave_lowres_7.jpg';
 
 const positions: Position[] = [];
 ---
-<BaseLayout title="Jobbe som designer | clave" backgroundColor={COLOR_CLAVE_PEACH}>
+<BaseLayout title="Jobbe som designer | clave">
   <RecruitmentTemplate positions={positions} uri="/jobb-som-designer">
     <Layout>
       <h1>Jobbe som designer</h1>

--- a/src/pages/jobb-som-designer.astro
+++ b/src/pages/jobb-som-designer.astro
@@ -3,19 +3,14 @@ import Layout from '../components/layout/Layout.astro';
 import Ingress from '../components/Ingress.astro';
 import MidSplitLayout from '../components/MidSplitLayout.astro';
 import RecruitmentTemplate from '../components/RecruitmentTemplate.astro';
+import BaseLayout from '../components/layout/BaseLayout.astro';
+import { COLOR_CLAVE_PEACH } from '../colors.js';
 import type { Position } from '../types';
 import piaBilde from '../assets/190920_Clave_lowres_7.jpg';
 
 const positions: Position[] = [];
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Jobbe som designer | clave</title>
-</head>
-<body>
+<BaseLayout title="Jobbe som designer | clave" backgroundColor={COLOR_CLAVE_PEACH}>
   <RecruitmentTemplate positions={positions} uri="/jobb-som-designer">
     <Layout>
       <h1>Jobbe som designer</h1>
@@ -55,8 +50,7 @@ const positions: Position[] = [];
       </ul>
     </MidSplitLayout>
   </RecruitmentTemplate>
-</body>
-</html>
+</BaseLayout>
 
 <style>
   .list {

--- a/src/pages/jobb-som-utvikler.astro
+++ b/src/pages/jobb-som-utvikler.astro
@@ -4,7 +4,6 @@ import Ingress from '../components/Ingress.astro';
 import MidSplitLayout from '../components/MidSplitLayout.astro';
 import RecruitmentTemplate from '../components/RecruitmentTemplate.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
-import { COLOR_CLAVE_PEACH } from '../colors.js';
 import type { Position } from '../types';
 import yngveBilde from '../assets/190920_Clave_lowres_13.jpg';
 
@@ -16,7 +15,7 @@ const positions: Position[] = [
   },
 ];
 ---
-<BaseLayout title="Jobbe som utvikler | clave" backgroundColor={COLOR_CLAVE_PEACH}>
+<BaseLayout title="Jobbe som utvikler | clave">
   <RecruitmentTemplate positions={positions} uri="/jobb-som-utvikler">
     <Layout>
       <h1>Jobbe som utvikler</h1>

--- a/src/pages/jobb-som-utvikler.astro
+++ b/src/pages/jobb-som-utvikler.astro
@@ -3,6 +3,8 @@ import Layout from '../components/layout/Layout.astro';
 import Ingress from '../components/Ingress.astro';
 import MidSplitLayout from '../components/MidSplitLayout.astro';
 import RecruitmentTemplate from '../components/RecruitmentTemplate.astro';
+import BaseLayout from '../components/layout/BaseLayout.astro';
+import { COLOR_CLAVE_PEACH } from '../colors.js';
 import type { Position } from '../types';
 import yngveBilde from '../assets/190920_Clave_lowres_13.jpg';
 
@@ -14,14 +16,7 @@ const positions: Position[] = [
   },
 ];
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Jobbe som utvikler | clave</title>
-</head>
-<body>
+<BaseLayout title="Jobbe som utvikler | clave" backgroundColor={COLOR_CLAVE_PEACH}>
   <RecruitmentTemplate positions={positions} uri="/jobb-som-utvikler">
     <Layout>
       <h1>Jobbe som utvikler</h1>
@@ -61,8 +56,7 @@ const positions: Position[] = [
       </ul>
     </MidSplitLayout>
   </RecruitmentTemplate>
-</body>
-</html>
+</BaseLayout>
 
 <style>
   .list {

--- a/src/pages/kontakt-oss.astro
+++ b/src/pages/kontakt-oss.astro
@@ -7,16 +7,10 @@ import Footer from '../components/layout/Footer.astro';
 import JoinSection from '../components/layout/JoinSection.astro';
 import Map from '../components/Map';
 import ContactForm from '../components/ContactForm.astro';
+import BaseLayout from '../components/layout/BaseLayout.astro';
 import '../styles/kontakt-oss.css';
 ---
-<html lang="nb">
-<head>
-    <meta charset="utf-8">
-    <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Kontakt oss | clave</title>
-</head>
-<body>
+<BaseLayout title="Kontakt oss | clave" backgroundColor={COLOR_CLAVE_GREEN}>
   <Container backgroundColor={COLOR_CLAVE_GREEN} textColor={COLOR_CLAVE_PEACH}>
     <main>
       <Header useSkinColoredHamburgerMenu={true} uri="/kontakt-oss" />
@@ -79,5 +73,4 @@ import '../styles/kontakt-oss.css';
     </main>
     <Footer backgroundColor={COLOR_CLAVE_GREEN} textColor={COLOR_CLAVE_PEACH} />
   </Container>
-</body>
-</html>
+</BaseLayout>

--- a/src/pages/kontakt-oss.astro
+++ b/src/pages/kontakt-oss.astro
@@ -10,7 +10,7 @@ import ContactForm from '../components/ContactForm.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
 import '../styles/kontakt-oss.css';
 ---
-<BaseLayout title="Kontakt oss | clave" backgroundColor={COLOR_CLAVE_GREEN}>
+<BaseLayout title="Kontakt oss | clave">
   <Container backgroundColor={COLOR_CLAVE_GREEN} textColor={COLOR_CLAVE_PEACH}>
     <main>
       <Header useSkinColoredHamburgerMenu={true} uri="/kontakt-oss" />

--- a/src/pages/prosjekter/eika.astro
+++ b/src/pages/prosjekter/eika.astro
@@ -1,18 +1,12 @@
 ---
 import ProjectTemplate from '../../components/ProjectTemplate.astro';
 import { COLOR_CLAVE_GREEN, COLOR_CLAVE_SUNNY } from '../../colors.js';
+import BaseLayout from '../../components/layout/BaseLayout.astro';
 import mainBilde from '../../assets/190920_Clave_lowres_1.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_4.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_3_crop.jpg';
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Eika | clave</title>
-</head>
-<body>
+<BaseLayout title="Eika | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}
@@ -49,5 +43,4 @@ import rightBilde from '../../assets/190920_Clave_lowres_3_crop.jpg';
       da med react native og ren native utvikling i Swift og Kotlin.
     </p>
   </ProjectTemplate>
-</body>
-</html>
+</BaseLayout>

--- a/src/pages/prosjekter/eika.astro
+++ b/src/pages/prosjekter/eika.astro
@@ -6,7 +6,7 @@ import mainBilde from '../../assets/190920_Clave_lowres_1.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_4.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_3_crop.jpg';
 ---
-<BaseLayout title="Eika | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
+<BaseLayout title="Eika | clave">
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}

--- a/src/pages/prosjekter/komplett.astro
+++ b/src/pages/prosjekter/komplett.astro
@@ -1,18 +1,12 @@
 ---
 import ProjectTemplate from '../../components/ProjectTemplate.astro';
 import { COLOR_CLAVE_GREEN, COLOR_CLAVE_SUNNY } from '../../colors.js';
+import BaseLayout from '../../components/layout/BaseLayout.astro';
 import mainBilde from '../../assets/190920_Clave_lowres_8.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_7.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_3.jpg';
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Komplett Group | clave</title>
-</head>
-<body>
+<BaseLayout title="Komplett Group | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}
@@ -53,5 +47,4 @@ import rightBilde from '../../assets/190920_Clave_lowres_3.jpg';
       som har hatt kort vei fra tegnebord til produksjon.
     </p>
   </ProjectTemplate>
-</body>
-</html>
+</BaseLayout>

--- a/src/pages/prosjekter/komplett.astro
+++ b/src/pages/prosjekter/komplett.astro
@@ -6,7 +6,7 @@ import mainBilde from '../../assets/190920_Clave_lowres_8.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_7.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_3.jpg';
 ---
-<BaseLayout title="Komplett Group | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
+<BaseLayout title="Komplett Group | clave">
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}

--- a/src/pages/prosjekter/naf.astro
+++ b/src/pages/prosjekter/naf.astro
@@ -1,18 +1,12 @@
 ---
 import ProjectTemplate from '../../components/ProjectTemplate.astro';
 import { COLOR_CLAVE_GREEN, COLOR_CLAVE_SUNNY } from '../../colors.js';
+import BaseLayout from '../../components/layout/BaseLayout.astro';
 import mainBilde from '../../assets/190920_Clave_lowres_6.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_13.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_18.jpg';
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NAF | clave</title>
-</head>
-<body>
+<BaseLayout title="NAF | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}
@@ -56,5 +50,4 @@ import rightBilde from '../../assets/190920_Clave_lowres_18.jpg';
       medlemmer og organisasjonen.
     </p>
   </ProjectTemplate>
-</body>
-</html>
+</BaseLayout>

--- a/src/pages/prosjekter/naf.astro
+++ b/src/pages/prosjekter/naf.astro
@@ -6,7 +6,7 @@ import mainBilde from '../../assets/190920_Clave_lowres_6.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_13.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_18.jpg';
 ---
-<BaseLayout title="NAF | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
+<BaseLayout title="NAF | clave">
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}

--- a/src/pages/prosjekter/the-well.astro
+++ b/src/pages/prosjekter/the-well.astro
@@ -1,18 +1,12 @@
 ---
 import ProjectTemplate from '../../components/ProjectTemplate.astro';
 import { COLOR_CLAVE_GREEN, COLOR_CLAVE_SUNNY } from '../../colors.js';
+import BaseLayout from '../../components/layout/BaseLayout.astro';
 import mainBilde from '../../assets/190920_Clave_lowres_15.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_14.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_12.jpg';
 ---
-<html lang="nb">
-<head>
-  <meta charset="utf-8">
-  <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>The Well | clave</title>
-</head>
-<body>
+<BaseLayout title="The Well | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}
@@ -55,5 +49,4 @@ import rightBilde from '../../assets/190920_Clave_lowres_12.jpg';
       Fabres i Polen.
     </p>
   </ProjectTemplate>
-</body>
-</html>
+</BaseLayout>

--- a/src/pages/prosjekter/the-well.astro
+++ b/src/pages/prosjekter/the-well.astro
@@ -6,7 +6,7 @@ import mainBilde from '../../assets/190920_Clave_lowres_15.jpg';
 import leftBilde from '../../assets/190920_Clave_lowres_14.jpg';
 import rightBilde from '../../assets/190920_Clave_lowres_12.jpg';
 ---
-<BaseLayout title="The Well | clave" backgroundColor={COLOR_CLAVE_SUNNY}>
+<BaseLayout title="The Well | clave">
   <ProjectTemplate
     mainImg={mainBilde.src}
     firstImg={leftBilde.src}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,7 @@
+@view-transition {
+  navigation: auto;
+}
+
 @font-face {
     font-family: 'basis-grotesque-medium-pro';
     src: url('/fonts/basis/basis-grotesque-medium-pro.eot');

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,7 @@ html {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
     font-size: 16px;
+    background-color: inherit;
 }
 
 body {


### PR DESCRIPTION
- Ny BaseLayout.astro samler felles <html>/<head>/<body>-shell — alle 12 sider bruker denne i stedet for å duplisere boilerplate
- Eliminerer hvit flash ved sidelast: background-color: inherit på <html> i global.css sørger for at nettleserens canvas alltid har riktig bakgrunnsfarge
- Native MPA view transitions via @view-transition { navigation: auto } i global.css gir jevne sideoverganger uten SPA-routing