### PR TITLE
Konfigurer cache-ing av statiske filer i netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,24 @@
 # path "root/project/dist"
 
 publish = "dist/"
+
+# Astro outputs all built images, JS and CSS to /_astro/ with content-hash
+# filenames (e.g. frontpage1.Ck3xP9aB.webp). The hash changes when content
+# changes, so it is safe to cache forever with immutable.
+[[headers]]
+  for = "/_astro/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Font files never change after deploy, so they can also be cached for a year.
+[[headers]]
+  for = "/fonts/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# HTML files are not hashed and must always revalidate so new deploys
+# are picked up immediately.
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -37,7 +37,7 @@ import frontpageImage from "../assets/frontpage1.png";
         </div>
       </div>
       <div class="bg-image">
-        <Image src={frontpageImage} alt="" />
+        <Image src={frontpageImage} alt="" fetchpriority="high" loading="eager" />
       </div>
     </div>
   </div>

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -47,6 +47,8 @@ const {
     width={imageWidth}
     height={imageHeight}
     alt={imageAlt}
+    fetchpriority="high"
+    loading="eager"
     />
   </ContainerContent>
   </div>

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -3,9 +3,10 @@ import '../../styles/global.css';
 
 interface Props {
   title: string;
+  description?: string;
 }
 
-const { title } = Astro.props;
+const { title, description } = Astro.props;
 ---
 <html lang="nb">
 <head>
@@ -13,6 +14,7 @@ const { title } = Astro.props;
   <link rel="icon" type="image/svg+xml" href="/clave-icon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{title}</title>
+  {description && <meta name="description" content={description} />}
   <link rel="preload" href="/fonts/basis/basis-grotesque-regular-pro.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="/fonts/basis/basis-grotesque-medium-pro.woff2" as="font" type="font/woff2" crossorigin />
 </head>

--- a/src/pages/hva-vi-gjor.astro
+++ b/src/pages/hva-vi-gjor.astro
@@ -14,7 +14,7 @@ import laptopBilde from '../assets/190920_Clave_lowres_16.jpg';
 import BaseLayout from '../components/layout/BaseLayout.astro';
 import ContainerContent from '../components/layout/ContainerContent.astro';
 ---
-<BaseLayout title="Se hva vi gjør | clave">
+<BaseLayout title="Se hva vi gjør | clave" description="Brukeropplevelse, systemutvikling og rådgivning er spesialitetene våre. Vi er stolte av jobbene vi gjør og enda stoltere av relasjonene vi bygger med kundene våre.">
   <Container>
     <main>
       <Header uri="/hva-vi-gjor" />

--- a/src/pages/hvem-vi-er.astro
+++ b/src/pages/hvem-vi-er.astro
@@ -8,7 +8,7 @@ import EmployeeList from '../components/dette-er-oss/EmployeeList.astro';
 import headerBilde from '../assets/190920_Clave_lowres_11.jpg';
 import BaseLayout from '../components/layout/BaseLayout.astro';
 ---
-<BaseLayout title="Se hvem vi er | clave">
+<BaseLayout title="Se hvem vi er | clave" description="Vi mener at det er godt og litt annerledes å være en Claver. Vi føler en tilhørighet både til selskapet og til kollegaene våre.">
   <Container>
     <main>
       <Header uri="/hvem-vi-er" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import { COLOR_CLAVE_GREEN, COLOR_CLAVE_PEACH } from '../colors.js';
 import HeroSection from '../components/HeroSection.astro';
 import Layout from '../components/layout/Layout.astro';
 import Container from '../components/layout/Container.astro';
+import ContainerContent from '../components/layout/ContainerContent.astro';
 import JoinSection from '../components/layout/JoinSection.astro';
 import Footer from '../components/layout/Footer.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
@@ -11,24 +12,23 @@ import brukeropplevelseIcon from '../assets/icons/clave_ikon_brukeropplevelse.sv
 import systemutviklingIcon from '../assets/icons/clave_ikon_systemutvikling.svg?url';
 import raadgivningIcon from '../assets/icons/clave_ikon_radgivning.svg?url';
 import { MAX_WIDTH } from '../layouts';
+import Ingress from '../components/Ingress.astro';
 ---
 
-<BaseLayout title="Forside | clave">
+<BaseLayout title="Forside | clave" description="Vi brenner for teknologi, innovasjon og å lage de aller beste løsningene for menneskene som skal bruke dem.">
   <HeroSection />
   <main>
     <Layout>
-      <div class="ingress-wrapper">
-        <p class="ingress">
-          Vi brenner for teknologi, innovasjon og å lage de aller beste
-          løsningene for menneskene som skal bruke dem. Vi er stolte av
-          jobbene vi gjør og enda stoltere av relasjonene vi bygger med
-          kundene våre.
-        </p>
-      </div>
+      <Ingress>
+        Vi brenner for teknologi, innovasjon og å lage de aller beste
+        løsningene for menneskene som skal bruke dem. Vi er stolte av
+        jobbene vi gjør og enda stoltere av relasjonene vi bygger med
+        kundene våre.
+      </Ingress>
     </Layout>
 
     <Container>
-      <div class="services-content">
+      <ContainerContent>
         <div class="wide-wrapper">
           <h2>Vi liker å drive med</h2>
           <div class="info-flexbox">
@@ -62,7 +62,7 @@ import { MAX_WIDTH } from '../layouts';
           </div>
           <a class="arrow-link" href="/hva-vi-gjor">Se mer om hva vi gjør →</a>
         </div>
-      </div>
+      </ContainerContent>
     </Container>
 
     <JoinSection />
@@ -75,14 +75,6 @@ import { MAX_WIDTH } from '../layouts';
 </BaseLayout>
 
 <style define:vars={{maxWidth: MAX_WIDTH}}>
-  .ingress-wrapper {
-    padding-top: 3rem;
-  }
-
-  .services-content {
-    max-width: var(--maxWidth);
-    margin: 0 auto;
-  }
 
   .wide-wrapper {
     padding: 0 3rem 4rem;

--- a/src/pages/jobb-som-designer.astro
+++ b/src/pages/jobb-som-designer.astro
@@ -9,7 +9,7 @@ import piaBilde from '../assets/190920_Clave_lowres_7.jpg';
 
 const positions: Position[] = [];
 ---
-<BaseLayout title="Jobbe som designer | clave">
+<BaseLayout title="Jobbe som designer | clave" description="Vi omskaper gode ideer til fungerende løsninger ved hjelp av dialog, faglig tyngde og grundige designprosesser.">
   <RecruitmentTemplate positions={positions} uri="/jobb-som-designer">
     <Layout>
       <h1>Jobbe som designer</h1>

--- a/src/pages/jobb-som-utvikler.astro
+++ b/src/pages/jobb-som-utvikler.astro
@@ -15,7 +15,7 @@ const positions: Position[] = [
   },
 ];
 ---
-<BaseLayout title="Jobbe som utvikler | clave">
+<BaseLayout title="Jobbe som utvikler | clave" description="Kjernen i alt vi driver med er folk som brenner for faget sitt og som er i kontinuerlig faglig utvikling.">
   <RecruitmentTemplate positions={positions} uri="/jobb-som-utvikler">
     <Layout>
       <h1>Jobbe som utvikler</h1>

--- a/src/pages/kontakt-oss.astro
+++ b/src/pages/kontakt-oss.astro
@@ -10,7 +10,7 @@ import ContactForm from '../components/ContactForm.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
 import { MAX_WIDTH } from '../layouts.js';
 ---
-<BaseLayout title="Kontakt oss | clave">
+<BaseLayout title="Kontakt oss | clave" description="Trenger du hjelp til noe, ønsker å vite mer om hvordan det er å jobbe hos oss eller rett og slett bare er litt nysgjerrig?">
   <Container backgroundColor={COLOR_CLAVE_GREEN} textColor={COLOR_CLAVE_PEACH}>
     <main>
       <Header useSkinColoredHamburgerMenu={true} uri="/kontakt-oss" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,5 @@
 @view-transition {
-  navigation: auto;
+  navigation: optional;
 }
 
 @font-face {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,5 @@
 @view-transition {
-  navigation: optional;
+  navigation: auto;
 }
 
 @font-face {
@@ -13,7 +13,7 @@
     url("/fonts/basis/basis-grotesque-medium-pro.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }
 
 @font-face {
@@ -27,7 +27,7 @@
     url("/fonts/basis/basis-grotesque-regular-pro.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }
 
 @font-face {


### PR DESCRIPTION
  LCP-optimalisering                                                                                                 
                                                                                                                     
  - Legger til fetchpriority="high" og loading="eager" på hero-bildet i HeroSection og header-bildet i PageHeader for
   å forhindre at Lighthouse rapporterer "lazy load not applied" på LCP-elementet                                    
                                                                                                                     
  Caching                                                                                                          

  - Legger til cache-headers i netlify.toml: hashed Astro-assets og fonter caches i ett år med immutable, HTML       
  revalideres alltid — eliminerer unødvendig re-fetch av bilder ved navigasjon
                                                                                                                     
  SEO                                                                                                              

  - Legger til valgfri description-prop i BaseLayout og setter meta description på hovedsidene