### PR TITLE
Refactor/css vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@
 │   │   │   └── ...
 │   │   └── ...
 │   ├── styles/
-│   │   └── global.css
-│   ├── colors.js                # Fargekonstanter (COLOR_CLAVE_*)
-│   ├── layouts.js               # Layout-konstanter (MAX_WIDTH, MOBILE_PADDING)
+│   │   └── global.css           # Globale stiler og CSS-variabler (farger, layout)
+│   ├── colors.js                # Fargekonstanter (COLOR_CLAVE_*) – brukes i JS/props
 │   └── types.ts
 └── package.json
 ```

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -98,7 +98,7 @@
     background-color: transparent;
     border: none;
     border-bottom: 1px solid #ccc;
-    color: #ffe6cd;
+    color: var(--clave-peach);
     box-sizing: border-box;
     font-size: 18px;
     height: 50px;
@@ -113,7 +113,7 @@
     background-color: transparent;
     border: none;
     border-bottom: 0.1em solid #ccc;
-    color: #ffe6cd;
+    color: var(--clave-peach);
     box-sizing: border-box;
     font-size: 23px;
     height: 50px;
@@ -123,7 +123,7 @@
   }
 
   .form-input.error::placeholder {
-    color: #fa9691;
+    color: var(--clave-pink);
     opacity: 1;
   }
 

--- a/src/components/ContactInfo.astro
+++ b/src/components/ContactInfo.astro
@@ -27,7 +27,7 @@ import Ingress from './Ingress.astro';
     margin-top: -0.2rem;
     display: block;
     height: 0.2rem;
-    background: #FA9691;
+    background: var(--clave-pink);
   }
 
   .underline:hover::after {
@@ -35,9 +35,9 @@ import Ingress from './Ingress.astro';
   }
 
   @keyframes hover {
-    0%   { background: #FA9691; transform: scaleX(1); }
-    50%  { background: #FA9691; transform: scaleX(0); }
-    51%  { background: #FFBE2D; transform: scaleX(0); }
-    100% { background: #FFBE2D; transform: scaleX(1); }
+    0%   { background: var(--clave-pink); transform: scaleX(1); }
+    50%  { background: var(--clave-pink); transform: scaleX(0); }
+    51%  { background: var(--clave-yellow); transform: scaleX(0); }
+    100% { background: var(--clave-yellow); transform: scaleX(1); }
   }
 </style>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -91,11 +91,11 @@ import frontpageImage from "../assets/frontpage1.png";
   }
 
   .prescroll {
-    background-color: #005550;
+    background-color: var(--clave-green);
   }
 
   .postscroll {
-    background-color: #ffe6cd;
+    background-color: var(--clave-peach);
     clip-path: circle(25vh at 85% 85%);
   }
 
@@ -117,13 +117,13 @@ import frontpageImage from "../assets/frontpage1.png";
 
   .title-wrapper {
     padding-top: 4.75rem;
-    padding-left: 3rem;
+    padding-left: var(--mobile-padding);
   }
 
   @media (min-width: 720px) {
     .title-wrapper {
-      padding-top: 6rem;
-      padding-left: 6rem;
+      padding-top: var(--desktop-padding);
+      padding-left: var(--desktop-padding);
     }
   }
 

--- a/src/components/MidSplitLayout.astro
+++ b/src/components/MidSplitLayout.astro
@@ -1,7 +1,6 @@
 ---
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
-import { MAX_WIDTH, MOBILE_PADDING } from '../layouts';
 
 interface Props {
   image: ImageMetadata;
@@ -31,16 +30,16 @@ const { image, imageHeight, imageWidth, imageAlt = "" } = Astro.props;
   </div>
 </div>
 
-<style define:vars={{maxWidth: MAX_WIDTH}}>
+<style>
   .wrapper {
-    background-color: #FFE6CD;
-    color: #005550;
+    background-color: var(--clave-peach);
+    color: var(--clave-green);
   }
 
   .content {
     display: grid;
     grid-template-columns: 1fr;
-    max-width: var(--maxWidth);
+    max-width: var(--max-width);
     margin: 0 auto;
   }
 
@@ -62,12 +61,12 @@ const { image, imageHeight, imageWidth, imageAlt = "" } = Astro.props;
   }
 
   .right {
-    padding: 3rem;
+    padding: var(--mobile-padding);
   }
 
   @media (min-width: 720px) {
     .right {
-      padding: 0 6rem 0 6rem;
+      padding: 0 var(--desktop-padding) 0 var(--desktop-padding);
     }
   }
 </style>

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -4,7 +4,6 @@ import type { ImageMetadata } from 'astro';
 import Container from './layout/Container.astro';
 import ContentColumn from './layout/ContentColumn.astro';
 import Ingress from './Ingress.astro';
-import { MOBILE_PADDING } from '../layouts';
 import { COLOR_CLAVE_PEACH, COLOR_CLAVE_GREEN } from '../colors.js';
 import ContainerContent from './layout/ContainerContent.astro';
 
@@ -48,9 +47,9 @@ const {
   </div>
 </Container>
 
-<style define:vars={{mobilePadding: MOBILE_PADDING}}>
+<style>
   .page-header-content-wrapper {
-    padding: 0 0 0 var(--mobilePadding);
+    padding: 0 0 0 var(--mobile-padding);
   }
   @media (min-width: 720px) {
     .page-header-content-wrapper {

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -38,7 +38,7 @@
   .project-container {
     margin: -70px -96px -90px -70px;
     padding: 70px 96px 120px 70px;
-    background-color: #FFD678;
+    background-color: var(--clave-mustard);
   }
 
   @media (max-width: 719px) {
@@ -69,7 +69,7 @@
     margin-top: 5px;
     display: block;
     height: 2px;
-    background: #FA9691;
+    background: var(--clave-pink);
   }
 
   .link-wrapper:hover::after {
@@ -77,10 +77,10 @@
   }
 
   @keyframes link-hover {
-    0%   { background: #FA9691; transform: scaleX(1); }
-    50%  { background: #FA9691; transform: scaleX(0); }
-    51%  { background: #FFBE2D; transform: scaleX(0); }
-    100% { background: #FFBE2D; transform: scaleX(1); }
+    0%   { background: var(--clave-pink); transform: scaleX(1); }
+    50%  { background: var(--clave-pink); transform: scaleX(0); }
+    51%  { background: var(--clave-yellow); transform: scaleX(0); }
+    100% { background: var(--clave-yellow); transform: scaleX(1); }
   }
 
   .right-arrow-link {
@@ -88,7 +88,7 @@
     font-size: 24px;
     margin: 20px -15px -3px 0;
     text-decoration: none;
-    color: #005550;
+    color: var(--clave-green);
   }
 
   .right-arrow-link::after {
@@ -108,7 +108,7 @@
     margin-top: -2px;
     border-top: 15px solid transparent;
     border-bottom: 15px solid transparent;
-    border-left: 20px solid #005550;
+    border-left: 20px solid var(--clave-green);
     transform: scaleX(0.6) scaleY(0.6);
   }
 

--- a/src/components/RecruitmentTemplate.astro
+++ b/src/components/RecruitmentTemplate.astro
@@ -46,7 +46,7 @@ const { positions, uri } = Astro.props;
     /* margin-top: 5px; */
     display: block;
     height: 2px;
-    background: #FA9691;
+    background: var(--clave-pink);
   }
 
   .back-link-wrapper:hover::after {
@@ -54,10 +54,10 @@ const { positions, uri } = Astro.props;
   }
 
   @keyframes link-hover {
-    0%   { background: #FA9691; transform: scaleX(1); }
-    50%  { background: #FA9691; transform: scaleX(0); }
-    51%  { background: #FFBE2D; transform: scaleX(0); }
-    100% { background: #FFBE2D; transform: scaleX(1); }
+    0%   { background: var(--clave-pink); transform: scaleX(1); }
+    50%  { background: var(--clave-pink); transform: scaleX(0); }
+    51%  { background: var(--clave-yellow); transform: scaleX(0); }
+    100% { background: var(--clave-yellow); transform: scaleX(1); }
   }
 
   .back-link {
@@ -65,7 +65,7 @@ const { positions, uri } = Astro.props;
     font-size: 24px;
     margin: 20px 0 -3px -40px;
     text-decoration: none;
-    color: #005550;
+    color: var(--clave-green);
   }
 
   .back-link::before {
@@ -84,7 +84,7 @@ const { positions, uri } = Astro.props;
     margin: -2px 20px -20px 0;
     border-top: 15px solid transparent;
     border-bottom: 15px solid transparent;
-    border-left: 20px solid #005550;
+    border-left: 20px solid var(--clave-green);
     transform: scaleX(-0.6) scaleY(0.6);
   }
 

--- a/src/components/SearchingForBanner.astro
+++ b/src/components/SearchingForBanner.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from './layout/Layout.astro';
 import type { Position } from '../types';
-
 interface Props {
   positions: Position[];
 }
@@ -27,18 +26,18 @@ const activePositions = positions.filter((p) => p.active);
 
 <style>
   .wrapper {
-    background-color: #B4D7E1;
-    color: #002850;
-    margin: -3rem -6rem -3rem 15%;
-    padding: 3rem;
+    background-color: var(--clave-lightblue);
+    color: var(--clave-blue);
+    margin: calc(-1 * var(--mobile-padding)) calc(-1 * var(--desktop-padding)) calc(-1 * var(--mobile-padding)) 15%;
+    padding: var(--mobile-padding);
   }
 
   .wrapper a {
-    color: #002850;
+    color: var(--clave-blue);
   }
 
   .wrapper a:visited {
-    color: #002850;
+    color: var(--clave-blue);
   }
   .wrapper ul {
     margin: 0;
@@ -47,7 +46,7 @@ const activePositions = positions.filter((p) => p.active);
 
   @media (max-width: 719px) {
     .wrapper {
-      margin: 0 -3rem;
+      margin: 0 calc(-1 * var(--mobile-padding));
     }
   }
 </style>

--- a/src/components/dette-er-oss/EmployeeList.astro
+++ b/src/components/dette-er-oss/EmployeeList.astro
@@ -1,36 +1,30 @@
 ---
 import { ansatte } from "./ansatte.json";
 
-import {
-    COLOR_CLAVE_PEACH,
-    COLOR_CLAVE_GREEN,
-} from "../../colors.js";
-
 import "../../styles/global.css";
 import EmployeeCard from "./EmployeeCard.astro";
-import { MAX_WIDTH } from "../../layouts";
 ---
 
-<style define:vars={{ COLOR_CLAVE_GREEN, COLOR_CLAVE_PEACH, maxWidth: MAX_WIDTH }}>
+<style>
     .this-is-us {
-        background-color: var(--COLOR_CLAVE_PEACH);
-        color: var(--COLOR_CLAVE_GREEN);
+        background-color: var(--clave-peach);
+        color: var(--clave-green);
         padding-bottom: 9rem;
     }
     .title {
         display: flex; 
         justify-content: center;
-        max-width: var(--maxWidth);
-        padding: 4rem 6rem;
+        max-width: var(--max-width);
+        padding: 4rem var(--desktop-padding);
         margin: 0 auto;
     }
     .employee-cards {
         display: grid;
         justify-content: center;
-        max-width: var(--maxWidth);
+        max-width: var(--max-width);
         grid-template-columns: repeat(auto-fit, minmax(280px, max-content));
-        gap: 4rem 6rem;
-        padding: 0 6rem;
+        gap: 4rem var(--desktop-padding);
+        padding: 0 var(--desktop-padding);
         margin: 0 auto;
     }
 </style>

--- a/src/components/icons/ClaveLogo.astro
+++ b/src/components/icons/ClaveLogo.astro
@@ -39,6 +39,6 @@ const { class: className, style } = Astro.props;
 
 <style>
   svg {
-    fill: var(--clave-text, #005550);
+    fill: var(--clave-text, var(--clave-green));
   }
 </style>

--- a/src/components/layout/Aside.astro
+++ b/src/components/layout/Aside.astro
@@ -1,6 +1,4 @@
 ---
-import { MOBILE_PADDING, DESKTOP_PADDING } from "../../layouts.js";
-
 interface Props {
   class?: string;
 }
@@ -12,18 +10,18 @@ const { class: className } = Astro.props;
   <slot />
 </aside>
 
-<style define:vars={{ mobilePadding: MOBILE_PADDING, desktopPadding: DESKTOP_PADDING }}>
+<style>
   .aside {
     flex: 1 0 40%;
     order: 1;
     display: flex;
-    padding: var(--mobilePadding) 0;
+    padding: var(--mobile-padding) 0;
   }
 
   @media screen and (min-width: 720px) {
     .aside {
       order: 0;
-      padding: 0 var(--desktopPadding) 0 0;
+      padding: 0 var(--desktop-padding) 0 0;
     }
   }
 </style>

--- a/src/components/layout/ContainerContent.astro
+++ b/src/components/layout/ContainerContent.astro
@@ -1,6 +1,4 @@
 ---
-import { MAX_WIDTH } from '../../layouts';
-
 interface Props {
   class?: string;
 }
@@ -12,9 +10,9 @@ const { class: className } = Astro.props;
   <slot />
 </div>
 
-<style define:vars={{maxWidth: MAX_WIDTH}}>
+<style>
   .container-content {
     margin: 0 auto;
-    max-width: var(--maxWidth);
+    max-width: var(--max-width);
   }
 </style>

--- a/src/components/layout/ContentColumn.astro
+++ b/src/components/layout/ContentColumn.astro
@@ -26,14 +26,14 @@ const { class: className, hasAside = Astro.slots.has("aside"), ...rest } = Astro
   .layout-wrapper {
     display: flex;
     flex-direction: column;
-    padding: 3rem;
-    padding-bottom: var(--column-padding-bottom, 3rem);
+    padding: var(--mobile-padding);
+    padding-bottom: var(--column-padding-bottom, var(--mobile-padding));
   }
 
   @media screen and (min-width: 720px) {
     .layout-wrapper {
-      padding: 6rem;
-      padding-bottom: var(--column-padding-bottom, 6rem);
+      padding: var(--desktop-padding);
+      padding-bottom: var(--column-padding-bottom, var(--desktop-padding));
       flex-direction: row;
     }
   }

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -4,9 +4,7 @@ import ClaveLogo from "../icons/ClaveLogo.astro";
 import {
   COLOR_CLAVE_GREEN,
   COLOR_CLAVE_PEACH,
-  COLOR_CLAVE_PINK,
 } from "../../colors.js";
-import { MAX_WIDTH, MOBILE_PADDING, DESKTOP_PADDING } from "../../layouts.js";
 import Container from "./Container.astro";
 import Section from "./Section.astro";
 
@@ -69,19 +67,19 @@ const {
   </Container>
 </footer>
 
-<style define:vars={{ colorPink: COLOR_CLAVE_PINK, textColor, maxWidth: MAX_WIDTH, mobilePadding: MOBILE_PADDING, desktopPadding: DESKTOP_PADDING }}>
+<style define:vars={{ textColor }}>
   .footer-content-container {
     display: flex;
     flex-direction: column-reverse;
-    padding: 6rem var(--mobilePadding) 9rem;
+    padding: 6rem var(--mobile-padding) 9rem;
   }
 
   @media (min-width: 720px) {
     .footer-content-container {
-      padding: 6rem var(--desktopPadding) 9rem;
+      padding: 6rem var(--desktop-padding) 9rem;
       flex-direction: row;
       margin: 0 auto;
-      max-width: var(--maxWidth);
+      max-width: var(--max-width);
     }
   }
 
@@ -118,7 +116,7 @@ const {
 
   .footer-link:hover {
     text-decoration: underline;
-    color: var(--colorPink);
+    color: var(--clave-pink);
   }
 
   .nowrap {

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,6 +1,5 @@
 ---
-import { COLOR_CLAVE_PINK, COLOR_CLAVE_YELLOW } from "../../colors";
-import { MAX_WIDTH } from "../../layouts";
+import { COLOR_CLAVE_PEACH, COLOR_CLAVE_GREEN } from "../../colors";
 import ClaveLogo from "../icons/ClaveLogo.astro";
 import HamburgerIcon from "../icons/HamburgerIcon.astro";
 import ContainerContent from "./ContainerContent.astro";
@@ -23,7 +22,7 @@ const menuLinks = [
   { label: "Kontakt oss", href: "/kontakt-oss" },
 ];
 
-const hamburgerFill = useSkinColoredHamburgerMenu ? "#FFE6CD" : "#005550";
+const hamburgerFill = useSkinColoredHamburgerMenu ? COLOR_CLAVE_PEACH : COLOR_CLAVE_GREEN;
 ---
 
 <header>
@@ -67,17 +66,17 @@ const hamburgerFill = useSkinColoredHamburgerMenu ? "#FFE6CD" : "#005550";
   </ContainerContent>
 </header>
 
-<style define:vars={{COLOR_CLAVE_PINK, COLOR_CLAVE_YELLOW, maxWidth: MAX_WIDTH}}>
+<style>
 
   .styled-header {
-    padding: 0 3rem;
+    padding: 0 var(--mobile-padding);
   }
 
   .wrapper {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: var(--clave-bg, #FFE6CD);
+    background: var(--clave-bg, var(--clave-peach));
     padding-top: 1.5rem;
   }
 
@@ -103,7 +102,7 @@ const hamburgerFill = useSkinColoredHamburgerMenu ? "#FFE6CD" : "#005550";
     margin-top: 5px;
     display: block;
     height: 2px;
-    background: var(--COLOR_CLAVE_PINK);
+    background: var(--clave-pink);
   }
 
   .nav-link-wrapper:hover::after {
@@ -112,25 +111,25 @@ const hamburgerFill = useSkinColoredHamburgerMenu ? "#FFE6CD" : "#005550";
 
   @keyframes link-hover {
     0% {
-      background: var(--COLOR_CLAVE_PINK);
+      background: var(--clave-pink);
       transform: scaleX(1);
     }
     50% {
-      background: var(--COLOR_CLAVE_PINK);
+      background: var(--clave-pink);
       transform: scaleX(0);
     }
     51% {
-      background: var(--COLOR_CLAVE_YELLOW);
+      background: var(--clave-yellow);
       transform: scaleX(0);
     }
     100% {
-      background: var(--COLOR_CLAVE_YELLOW);
+      background: var(--clave-yellow);
       transform: scaleX(1);
     }
   }
 
   .nav-link {
-    color: var(--clave-text, #005550);
+    color: var(--clave-text, var(--clave-green));
     text-decoration: none;
     margin-left: 0.5rem;
     margin-right: 0.5rem;
@@ -175,21 +174,21 @@ const hamburgerFill = useSkinColoredHamburgerMenu ? "#FFE6CD" : "#005550";
   }
 
   .hamburger-link {
-    color: var(--clave-text, #005550);
+    color: var(--clave-text, var(--clave-green));
     text-decoration: none;
-    border-bottom: 1px solid var(--COLOR_CLAVE_PINK);
+    border-bottom: 1px solid var(--clave-pink);
     display: table;
     padding: 0.5rem 0;
   }
 
   .hamburger-link.active {
-    border-bottom-color: var(--COLOR_CLAVE_YELLOW);
+    border-bottom-color: var(--clave-yellow);
   }
 
   /* Responsive */
   @media (min-width: 720px) {
     .styled-header {
-      padding: 0 6rem;
+      padding: 0 var(--desktop-padding);
     }
 
     .wrapper {

--- a/src/components/layout/JoinSection.astro
+++ b/src/components/layout/JoinSection.astro
@@ -62,8 +62,8 @@ const {
   }
   @media only screen and (max-width: 719px) {
     .aside-div {
-      padding: 3rem;
-      margin: 3rem -3rem 0;
+      padding: var(--mobile-padding);
+      margin: var(--mobile-padding) calc(-1 * var(--mobile-padding)) 0;
     }
   }
 

--- a/src/layouts.js
+++ b/src/layouts.js
@@ -1,3 +1,0 @@
-export const MAX_WIDTH = "120rem";
-export const MOBILE_PADDING = "3rem";
-export const DESKTOP_PADDING = "6rem";

--- a/src/pages/apenhetsloven.astro
+++ b/src/pages/apenhetsloven.astro
@@ -3,7 +3,6 @@ import pdf from "../assets/apenhetsloven/Åpenhetsloven Clave Consulting AS.pdf"
 import Header from "../components/layout/Header.astro";
 import Container from "../components/layout/Container.astro";
 import BaseLayout from "../components/layout/BaseLayout.astro";
-import { MAX_WIDTH } from "../layouts";
 ---
 
 <BaseLayout title="Åpenhetsloven | clave">
@@ -19,12 +18,12 @@ import { MAX_WIDTH } from "../layouts";
   </Container>
 </BaseLayout>
 
-<style define:vars={{maxWidth: MAX_WIDTH}}>
+<style>
   .title {
     display: flex;
     justify-content: center;
     flex-direction: column;
-    padding: 9rem 6rem;
+    padding: 9rem var(--desktop-padding);
     margin: 0 auto;
     max-width: fit-content;
   }
@@ -33,8 +32,8 @@ import { MAX_WIDTH } from "../layouts";
     display: flex;
     justify-content: center;
     flex-direction: column;
-    max-width: var(--maxWidth);
-    padding: 3rem 6rem;
+    max-width: var(--max-width);
+    padding: var(--mobile-padding) var(--desktop-padding);
     margin: 0 auto 100%;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,6 @@ import BaseLayout from '../components/layout/BaseLayout.astro';
 import brukeropplevelseIcon from '../assets/icons/clave_ikon_brukeropplevelse.svg?url';
 import systemutviklingIcon from '../assets/icons/clave_ikon_systemutvikling.svg?url';
 import raadgivningIcon from '../assets/icons/clave_ikon_radgivning.svg?url';
-import { MAX_WIDTH } from '../layouts';
 import Ingress from '../components/Ingress.astro';
 ---
 
@@ -74,15 +73,15 @@ import Ingress from '../components/Ingress.astro';
   <script is:inline async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 </BaseLayout>
 
-<style define:vars={{maxWidth: MAX_WIDTH}}>
+<style>
 
   .wide-wrapper {
-    padding: 0 3rem 4rem;
+    padding: 0 var(--mobile-padding) 4rem;
   }
 
   @media (min-width: 720px) {
     .wide-wrapper {
-      padding: 0 6rem 8rem;
+      padding: 0 var(--desktop-padding) 8rem;
     }
   }
 
@@ -129,7 +128,7 @@ import Ingress from '../components/Ingress.astro';
   }
 
   .arrow-link {
-    color: #005550;
+    color: var(--clave-green);
     text-decoration: none;
     font-size: 1.125rem;
   }

--- a/src/pages/kontakt-oss.astro
+++ b/src/pages/kontakt-oss.astro
@@ -8,7 +8,6 @@ import JoinSection from '../components/layout/JoinSection.astro';
 import Map from '../components/Map';
 import ContactForm from '../components/ContactForm.astro';
 import BaseLayout from '../components/layout/BaseLayout.astro';
-import { MAX_WIDTH } from '../layouts.js';
 ---
 <BaseLayout title="Kontakt oss | clave" description="Trenger du hjelp til noe, ønsker å vite mer om hvordan det er å jobbe hos oss eller rett og slett bare er litt nysgjerrig?">
   <Container backgroundColor={COLOR_CLAVE_GREEN} textColor={COLOR_CLAVE_PEACH}>
@@ -75,20 +74,20 @@ import { MAX_WIDTH } from '../layouts.js';
   </Container>
 </BaseLayout>
 
-<style define:vars={{ colorGreen: COLOR_CLAVE_GREEN, maxWidth: MAX_WIDTH }}>
+<style>
   .title-wrapper {
-    background-color: var(--colorGreen);
+    background-color: var(--clave-green);
     padding-top: 4.75rem;
   }
 
   @media screen and (min-width: 720px) {
     .title-wrapper {
-      padding-top: 6rem;
+      padding-top: var(--desktop-padding);
     }
   }
 
   .contact-info {
-    max-width: var(--maxWidth);
+    max-width: var(--max-width);
     display: flex;
     flex-direction: column;
     padding-left: 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,23 @@
   navigation: auto;
 }
 
+:root {
+  /* Colors */
+  --clave-peach: #FFE6CD;
+  --clave-green: #005550;
+  --clave-pink: #FA9691;
+  --clave-yellow: #FFBE2D;
+  --clave-lightblue: #B4D7E1;
+  --clave-mustard: #FFD678;
+  --clave-blue: #002850;
+  --clave-sunny: #FFE099;
+
+  /* Layout */
+  --max-width: 120rem;
+  --mobile-padding: 3rem;
+  --desktop-padding: 6rem;
+}
+
 @font-face {
   font-family: "basis-grotesque-medium-pro";
   src: url("/fonts/basis/basis-grotesque-medium-pro.eot");


### PR DESCRIPTION
Hardkodede hex-verdier og layout-konstanter er erstattet med CSS custom properties definert i :root i global.css. Fjerner behovet for define:vars og JS-import i komponenter som bare bruker verdiene i CSS. layouts.js er slettet siden alle verdiene nå lever i global.css.