### PR TITLE
Dokumenter oppsett av Google Maps og miljøvariabler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,60 @@ Alle kommandoer kjøres fra rotnivå:
 | `npm run build`           | Bygg produksjonsside til `./dist/`               |
 | `npm run preview`         | Forhåndsvis bygget lokalt før deploy             |
 | `npm run astro ...`       | Kjør Astro CLI-kommandoer                        |
+
+## 🔑 Miljøvariabler
+
+Lag en `.env` på rotnivå (filen er gitignorert):
+
+| Variabel                     | Brukes av                  | Beskrivelse                                  |
+| :--------------------------- | :------------------------- | :------------------------------------------- |
+| `PUBLIC_GOOGLE_MAPS_API_KEY` | `src/components/Map.astro` | Google Maps-nøkkel for kartet på `/kontakt-oss` |
+
+Verdien ligger i Netlify under Site configuration → Environment variables.
+
+Mangler `.env`, bygger Astro inn `key=undefined` uten at bygget feiler. Kartet
+viser da «The provided API key is invalid», som peker på nøkkelen framfor på
+den manglende filen.
+
+## 🗺️ Google Maps
+
+`Map.astro` er en server-rendret iframe mot **Maps Embed API**. Merk at dette er
+et annet API enn Maps JavaScript API, som den tidligere React-komponenten brukte.
+Embed API må være aktivert på Cloud-prosjektet, ellers svarer Google med «This API
+is not activated on your API project».
+
+Nøkkelen har `PUBLIC_`-prefiks og er dermed synlig i sidekilden. Den er derfor
+begrenset med website restrictions, noe som har to konsekvenser:
+
+- **Lokal utvikling** krever at `http://localhost:4321/*` og `http://localhost/*`
+  ligger i restriksjonslista. Legg til begge — Googles matching av portnummer er
+  ikke konsistent.
+- **Deploy previews kan ikke vise kartet.** De kjører på
+  `deploy-preview-<PR>--<site>.netlify.app`, og `*.netlify.app/*` avvises av Google
+  fordi `netlify.app` står på Public Suffix List. Et ødelagt kart i en preview sier
+  altså ingenting om prod.
+
+Verifiser prod-stien etter et bygg ved å hente ut den genererte URL-en og kalle
+den slik en besøkende på clave.no ville gjort:
+
+```bash
+URL=$(grep -o 'src="https://www.google.com/maps/embed/v1/place?[^"]*"' \
+      dist/kontakt-oss/index.html | sed 's/src="//;s/"$//;s/&amp;/\&/g')
+curl -s -o /dev/null -w "%{http_code}\n" -H "Referer: https://clave.no/" "$URL"
+```
+
+`200` betyr at hele kjeden virker: env-variabelen nådde `Map.astro`, URL-en er
+riktig bygget, nøkkelen er gyldig, Embed API er aktivert og referrer-restriksjonen
+slipper gjennom clave.no.
+
+### Feilmeldinger
+
+Alle kommer som 401/403 fra samme endepunkt — det er kun teksten som skiller dem:
+
+| Melding fra Google                                     | Årsak                                    |
+| :----------------------------------------------------- | :--------------------------------------- |
+| You must use an API key                                | `key=` – variabelen er tom i shellet     |
+| The provided API key is invalid                        | `key=undefined` – `.env` mangler         |
+| The provided API key is expired                        | Gammel eller slettet nøkkel              |
+| This IP, site or mobile application is not authorized  | Referrer ikke i restriksjonslista        |
+| This API is not activated on your API project          | Maps Embed API ikke aktivert i prosjektet |


### PR DESCRIPTION
Dokumenterer oppsettet rundt kartet. Ingenting av dette lå i repoet før, og det var årsaken til at #97 ble revertert i #98 og deretter måtte gjeninnføres i #99.

## Bakgrunn

Feilsøkingen av kartet gikk gjennom fem forskjellige feilmeldinger fra Google, alle 401/403 fra samme endepunkt. De pekte på helt ulike årsaker — manglende `.env`, feil API aktivert, utgått nøkkel, referrer-restriksjon — men teksten er det eneste som skiller dem, og ingen av dem var beskrevet noe sted.

Særlig én er villedende: uten `.env` bygger Astro inn `key=undefined` uten at bygget feiler, og Google svarer «The provided API key is invalid». Meldingen peker på nøkkelen framfor på den manglende filen.

## Hva som dokumenteres

- **Miljøvariabler** — `PUBLIC_GOOGLE_MAPS_API_KEY`, hvilken komponent som bruker den, og hvor verdien hentes fra i Netlify
- **Maps Embed API vs Maps JavaScript API** — `Map.astro` bruker Embed API. Git-historikken peker mot JavaScript API, siden det var det den gamle React-komponenten brukte, så dette er en lett felle å gå i
- **Referrer-restriksjonene** — hvilke `localhost`-mønstre som må legges til for lokal utvikling, og hvorfor deploy previews ikke kan vise kartet i det hele tatt (`*.netlify.app/*` avvises fordi `netlify.app` står på Public Suffix List)
- **Verifiseringskommando** — henter ut den genererte iframe-URL-en fra `dist/` og kaller den med `Referer: https://clave.no/`. `200` dekker hele kjeden i én sjekk
- **Feilmeldingstabell** — knytter hver av Googles meldinger til faktisk årsak

Punktet om deploy previews er verdt å merke seg for framtidige PR-er: et ødelagt kart i en preview sier ingenting om prod, og bør ikke leses som en regresjon.

## Merk

Kun `README.md` er endret — ingen kodeendring, ingen ny avhengighet. Nøkkelen selv står ikke i teksten.

Gjenstår utenfor repoet, nå som prod er bekreftet grønn: begrense nøkkelen til Maps Embed API, skru av Maps JavaScript API (ingenting bruker det etter #99), og slette den utgåtte nøkkelen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
